### PR TITLE
Update CreateShortUrl.php

### DIFF
--- a/src/Filament/Resources/ShortUrlResource/Pages/CreateShortUrl.php
+++ b/src/Filament/Resources/ShortUrlResource/Pages/CreateShortUrl.php
@@ -2,13 +2,14 @@
 
 namespace A21ns1g4ts\FilamentShortUrl\Filament\Resources\ShortUrlResource\Pages;
 
-use A21ns1g4ts\FilamentShortUrl\Filament\Resources\ShortUrlResource;
+use Filament\Actions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Filament\Resources\Pages\CreateRecord;
 use AshAllenDesign\ShortURL\Classes\Builder;
 use AshAllenDesign\ShortURL\Models\ShortURL;
-use Filament\Actions;
-use Filament\Resources\Pages\CreateRecord;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Carbon;
+use A21ns1g4ts\FilamentShortUrl\Filament\Resources\ShortUrlResource;
 
 class CreateShortUrl extends CreateRecord
 {
@@ -20,7 +21,9 @@ class CreateShortUrl extends CreateRecord
             ->when($data['activated_at'], fn (Builder $builder) => $builder->activateAt(Carbon::parse($data['activated_at'])))
             ->when($data['deactivated_at'], fn (Builder $builder) => $builder->deactivateAt(Carbon::parse($data['deactivated_at'])))
             ->beforeCreate(function (ShortURL $model): void {
-                $model->company_id = auth()->user()->current_company_id;
+                if (Schema::hasColumn('short_urls', 'company_id')) {
+                    $model->company_id = auth()->user()->current_company_id;
+                }
             })
             ->make();
 


### PR DESCRIPTION
You get Internal Server Error when you try to add a new shorturl because the short url model doesn't have a company_id column. I fixed it with a check before adding it.

SQLSTATE[HY000]: General error: 1 table short_urls has no column named company_id